### PR TITLE
adds generation of integration file from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,55 +25,7 @@ Or install it yourself as:
 
 You must have `nib` version `>= 2` in order for this plugin to work.
 
-Your applications must also have docker-compose configuration that allows
-the containers to exist on the same network as containers in other projects.
 
-This is accomplished by using the `docker network` settings available in
-docker-compose.
-
-Here is a sample configuration for external networking for a docker-compose
-service. Let's assume that the web service has been defined in the
-`docker-compose.yml` file.
-
-```
-# app1/docker-compose-integration.yml
-
-services:
-  web:
-    external_links:
-      - myexternalservice_web_1:ex-1
-    networks:
-      - default
-      - outside
-networks:
-  outside:
-    external:
-      name: inter-service-network
-```
-
-In this example, the "inter-service-network" will have been created by this command:
-
-```
-docker network create inter-service-network
-```
-
-In the external service docker-compose.yml file, the following configuration
-would exist:
-
-```
-# external_service/docker-compose.yml
-
-
-services:
-  web:
-    networks:
-      - default
-      - outside
-networks:
-  outside:
-    external:
-      name: inter-service-network
-```
 
 ## Usage
 
@@ -89,7 +41,7 @@ The init step must be done before any of the other commands will work.
 To register app1 from above for use with `nib-integrate`:
 
 ```
-nib integrate register -a app1 -p /path/to/src/app1 -s web -i docker-compose-integration.yml
+nib integrate register -a app1 -p /path/to/src/app1 -s web
 ```
 
 To register external_service from above for use with `nib-integrate`:
@@ -119,6 +71,31 @@ To list registered services:
 ```
 nib integrate list
 ```
+
+## Under The Hood
+
+When the up command is run, a dynamically generated integration file is
+generated. This file puts the service container in the default network
+and the nib-integrate-network. and provides an external link to all other
+registered services. This file is then passed as an additional configuration
+file to the docker-compose command that is generated when `up` is called.
+
+```
+# app1/docker-compose-integration.yml
+
+services:
+  web:
+    external_links:
+      - myexternalservice_web_1:myexternalservice_web
+    networks:
+      - default
+      - outside
+networks:
+  outside:
+    external:
+      name: inter-service-network
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ services:
 networks:
   outside:
     external:
-      name: inter-service-network
+      name: nib-integrate-network
 ```
 
 

--- a/bin/nib-integrate
+++ b/bin/nib-integrate
@@ -8,8 +8,10 @@ command :integrate do |c|
   c.desc 'intialize gem and create config file'
   c.command :init do |ic|
     ic.action do |_global_options, _options, _args|
+      next if File.exist?(Nib::Integrate::ConfigFile::PATH)
       Nib::Integrate::ConfigFile
         .write(Nib::Integrate::ConfigFile::DEFAULT_CONFIG)
+      Nib::Integrate::NetworkCreator.call
     end
   end
 

--- a/bin/nib-integrate
+++ b/bin/nib-integrate
@@ -26,8 +26,6 @@ command :integrate do |c|
             description: 'docker_compose yml file',
             required: false,
             default_value: 'docker-compose.yml'
-    rc.flag [:i, :integration_file, 'integration-file'],
-            description: 'the integration docker-compose file', required: false
     rc.action do |_global_options, options, _args|
       Nib::Integrate::Registrar.call(options)
     end

--- a/lib/nib/integrate/integration_file.rb
+++ b/lib/nib/integrate/integration_file.rb
@@ -1,0 +1,96 @@
+module Nib
+  module Integrate
+    # dynamically generated network config file
+    class IntegrationFile
+      class << self
+        def write(app_name)
+          new(app_name).write
+        end
+      end
+
+      attr_reader :app_name
+
+      def initialize(app_name)
+        @app_name = app_name
+      end
+
+      def write
+        File.open(path, 'w') do |f|
+          f.write(config.to_yaml)
+        end
+        path
+      end
+
+      private
+
+      def apps
+        @apps ||= global_config['apps']
+      end
+
+      def app
+        apps.find { |a| a['name'] == app_name }
+      end
+
+      def other_apps
+        apps.reject { |a| a['name'] == app_name }
+      end
+
+      def path
+        "#{ENV['HOME']}/.nib-integrate-network-config-#{app['name']}"
+      end
+
+      def config
+        app_services.each_with_object(network_config) do |elem, acc|
+          acc['services'] = {
+            elem => {
+              'external_links' =>  external_links,
+              'networks' => %w[default nib]
+            }
+          }
+        end
+      end
+
+      def external_links
+        other_apps.map(&external_link)
+      end
+
+      def external_link
+        lambda do |registration|
+          "#{container_name(registration)}_1:#{container_name(registration)}"
+        end
+      end
+
+      def container_name(registration)
+        project_name = registration['path'].split('/').last.gsub(/[ _]/, '')
+        service_name = registration['service']
+        "#{project_name}_#{service_name}"
+      end
+
+      def network_config
+        {
+          'version' => '2',
+          'services' => {},
+          'networks' => {
+            'nib' => { 'external' => { 'name' => 'nib-integrate-network' } }
+          }
+        }
+      end
+
+      def app_docker_compose
+        @app_docker_compose ||= app_compose_contents
+      end
+
+      def app_compose_contents
+        YAML.load_file("#{app['path']}/#{app['compose_file']}")
+      end
+
+      def app_services
+        app_docker_compose['services'].keys
+      end
+
+      def global_config
+        ConfigFile.read
+      end
+    end
+  end
+end

--- a/lib/nib/integrate/integration_file.rb
+++ b/lib/nib/integrate/integration_file.rb
@@ -41,11 +41,9 @@ module Nib
 
       def config
         app_services.each_with_object(network_config) do |elem, acc|
-          acc['services'] = {
-            elem => {
-              'external_links' =>  external_links,
-              'networks' => %w[default nib]
-            }
+          acc['services'][elem] = {
+            'external_links' =>  external_links,
+            'networks' => %w[default nib]
           }
         end
       end

--- a/lib/nib/integrate/integrator.rb
+++ b/lib/nib/integrate/integrator.rb
@@ -71,12 +71,19 @@ module Nib
       end
 
       def integration_file_flag
-        return unless app['integration_file'] && !app['integration_file'].empty?
-        "-f #{app['integration_file']}"
+        "-f #{integration_file_path}"
+      end
+
+      def integration_file_path
+        integration_file.write(app['name'])
       end
 
       def config_file
         ConfigFile
+      end
+
+      def integration_file
+        IntegrationFile
       end
     end
   end

--- a/lib/nib/integrate/network_creator.rb
+++ b/lib/nib/integrate/network_creator.rb
@@ -1,0 +1,22 @@
+module Nib
+  module Integrate
+    # NetworkCreator creates the nib-integrate-network
+    class NetworkCreator
+      class << self
+        def call
+          create_network unless network_exists?
+        end
+
+        private
+
+        def create_network
+          system 'docker network create nib-integrate-network'
+        end
+
+        def network_exists?
+          `docker network ls` =~ /nib-integrate-network/
+        end
+      end
+    end
+  end
+end

--- a/lib/nib_integrate_plugin.rb
+++ b/lib/nib_integrate_plugin.rb
@@ -1,8 +1,10 @@
-require 'nib/integrate/version'
-require 'nib/integrate/integrator'
 require 'nib/integrate/config_file'
-require 'nib/integrate/registrar'
+require 'nib/integrate/integration_file'
+require 'nib/integrate/integrator'
+require 'nib/integrate/network_creator'
 require 'nib/integrate/lister'
+require 'nib/integrate/registrar'
+require 'nib/integrate/version'
 
 module Nib
   # integrates multiple docker containers

--- a/spec/lib/nib/integrate/integration_file_spec.rb
+++ b/spec/lib/nib/integrate/integration_file_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Nib::Integrate::IntegrationFile do
+  subject { described_class }
+  let(:instance) { subject.new(app_name) }
+  let(:app_name) { 'foo' }
+  let(:app_path) do
+    "#{ENV['HOME']}/.nib-integrate-network-config-#{app_name}"
+  end
+  let(:config) do
+    {
+      'apps' => [
+        {
+          'name' => 'foo',
+          'path' => '/path/to/foo_app',
+          'service' => 'web',
+          'compose_file' => 'docker-compose.yml'
+        },
+        {
+          'name' => 'bar',
+          'path' => '/path/to/bar_app',
+          'service' => 'api',
+          'compose_file' => 'docker-compose.yml'
+        }
+      ]
+    }
+  end
+  let(:app_config) do
+    {
+      'services' => {
+        'web' => {
+          'volumes' => []
+        }
+      }
+    }
+  end
+  let(:integration_config) do
+    {
+      'version' => '2',
+      'services' => {
+        'web' => {
+          'external_links' => ['barapp_api_1:barapp_api'],
+          'networks' => %w[default nib]
+        }
+      },
+      'networks' => {
+        'nib' => {
+          'external' => {
+            'name' => 'nib-integrate-network'
+          }
+        }
+      }
+    }
+  end
+
+  before do
+    allow(instance).to receive(:global_config).and_return(config)
+    allow(instance).to receive(:app_compose_contents).and_return(app_config)
+  end
+  it 'produces a flie with a network configuration given an app name' do
+    expect(instance.write).to eq app_path
+  end
+
+  it 'produces a flie with a network configuration' do
+    path = instance.write
+    expect(YAML.load_file(path)).to eq integration_config
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/lib/nib/integrate/integrator_spec.rb
+++ b/spec/lib/nib/integrate/integrator_spec.rb
@@ -24,12 +24,14 @@ RSpec.describe Nib::Integrate::Integrator do
     }
   end
   let(:config_file) { double(:config_file) }
+  # rubocop:disable Metrics/LineLength
   let(:command_strings) do
     [
-      'cd /foo/path && docker-compose -f docker-compose.yml up -d web',
-      'cd /bar/path && docker-compose -f d-c-web.yml -f int.yml up -d worker'
+      'cd /foo/path && docker-compose -f docker-compose.yml -f foo.yml up -d web',
+      'cd /bar/path && docker-compose -f d-c-web.yml -f foo.yml up -d worker'
     ]
   end
+  # rubocop:enable Metrics/LineLength
 
   let(:down_command_strings) do
     [
@@ -42,6 +44,8 @@ RSpec.describe Nib::Integrate::Integrator do
     allow_any_instance_of(subject)
       .to receive(:config_file).and_return(config_file)
     allow(config_file).to receive(:read).and_return(config)
+    allow_any_instance_of(subject)
+      .to receive(:integration_file_path).and_return('foo.yml')
   end
 
   it 'has an up method' do


### PR DESCRIPTION
The `nib integrate up [apps...]` command now generates integration files
on the fly. This implements Issue #1. The integration file is
generated in the home folder and is paased to the docker-compose command
as a separate docker-compose configuration file. This places the container
in the nib-integrate-network and builds links to all the other registered
services